### PR TITLE
HornArmor cleanup / enhancement

### DIFF
--- a/src/main/java/superlord/ravagecabbage/entity/RCRavagerEntity.java
+++ b/src/main/java/superlord/ravagecabbage/entity/RCRavagerEntity.java
@@ -583,6 +583,7 @@ public class RCRavagerEntity extends TameableEntity implements IRideable, IEquip
 				this.entityDropItem(itemStack.copy());
 				this.setItemStackToSlot(EquipmentSlotType.HEAD, ItemStack.EMPTY);
 			}
+			return ActionResultType.CONSUME;
 
 		} else if (this.isSaddled() && item == Items.AIR) {
 			player.startRiding(this);

--- a/src/main/java/superlord/ravagecabbage/entity/RCRavagerEntity.java
+++ b/src/main/java/superlord/ravagecabbage/entity/RCRavagerEntity.java
@@ -41,7 +41,6 @@ import net.minecraft.entity.passive.horse.AbstractHorseEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.projectile.AbstractArrowEntity;
 import net.minecraft.inventory.EquipmentSlotType;
-import net.minecraft.item.HorseArmorItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
@@ -76,7 +75,7 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import superlord.ravagecabbage.init.RCEntities;
 import superlord.ravagecabbage.init.RCItems;
-import superlord.ravagecabbage.items.RavagerHornArmorItem;
+import superlord.ravagecabbage.items.IRavagerHornArmorItem;
 
 import static net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent;
 
@@ -222,7 +221,15 @@ public class RCRavagerEntity extends TameableEntity implements IRideable, IEquip
 		compound.putInt("StunTick", this.stunTick);
 		compound.putInt("RoarTick", this.roarTick);
 		compound.putBoolean("IsSaddled", this.isSaddled());
-		compound.putBoolean("HasHornArmor", this.hasHornArmor());
+
+
+		ItemStack itemStackHead = this.getItemStackFromSlot(EquipmentSlotType.HEAD);
+		if(!itemStackHead.isEmpty()) {
+			CompoundNBT headCompoundNBT = new CompoundNBT();
+			itemStackHead.write(headCompoundNBT);
+			compound.put("HeadSlot", headCompoundNBT);
+		}
+
 	}
 
 	@Override
@@ -232,7 +239,13 @@ public class RCRavagerEntity extends TameableEntity implements IRideable, IEquip
 		this.stunTick = compound.getInt("StunTick");
 		this.roarTick = compound.getInt("RoarTick");
 		this.setSaddled(compound.getBoolean("IsSaddled"));
-		this.setHasHornArmor(compound.getBoolean("HasHornArmor"));
+
+		CompoundNBT compoundNBT = compound.getCompound("HeadSlot");
+		boolean hasHornArmor = !compoundNBT.isEmpty();
+		if(hasHornArmor) {
+			this.setItemStackToSlot(EquipmentSlotType.HEAD, ItemStack.read(compoundNBT));
+		}
+		this.setHasHornArmor(hasHornArmor);
 	}
 
 	@Override
@@ -296,7 +309,7 @@ public class RCRavagerEntity extends TameableEntity implements IRideable, IEquip
 	}
 
 	public static AttributeModifierMap.MutableAttribute func_234233_eS_() {
-		return MobEntity.func_233666_p_().createMutableAttribute(Attributes.MAX_HEALTH, 100.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.3D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.75D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 6.0D).createMutableAttribute(Attributes.ATTACK_KNOCKBACK, 1.5D).createMutableAttribute(Attributes.FOLLOW_RANGE, 32.0D);
+		return MobEntity.func_233666_p_().createMutableAttribute(Attributes.MAX_HEALTH, 100.0D).createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.3D).createMutableAttribute(Attributes.KNOCKBACK_RESISTANCE, 0.75D).createMutableAttribute(Attributes.ATTACK_DAMAGE, 6.0D).createMutableAttribute(Attributes.ATTACK_KNOCKBACK, 1.5D).createMutableAttribute(Attributes.FOLLOW_RANGE, 32.0D).createMutableAttribute(Attributes.ARMOR, 0D);
 	}
 
 	@Override
@@ -501,6 +514,21 @@ public class RCRavagerEntity extends TameableEntity implements IRideable, IEquip
 		}
 	}
 
+
+	public void setItemStackToSlot(EquipmentSlotType slotIn, ItemStack itemStack) {
+		super.setItemStackToSlot(slotIn, itemStack);
+
+		if(slotIn == EquipmentSlotType.HEAD && itemStack != null && !itemStack.isEmpty()) {
+			Item item = itemStack.getItem();
+			if(item instanceof IRavagerHornArmorItem) {
+				IRavagerHornArmorItem hornArmor = (IRavagerHornArmorItem)item;
+
+				// and update this Entity's Atttributes.ARMOR base
+				this.getAttribute(Attributes.ARMOR).setBaseValue((double) hornArmor.getArmorValue());
+			}
+		}
+	}
+
 	@Override
 	public ItemStack getPickedResult(RayTraceResult target) {
 		return new ItemStack(RCItems.RAVAGER_SPAWN_EGG.get());
@@ -540,54 +568,18 @@ public class RCRavagerEntity extends TameableEntity implements IRideable, IEquip
 			world.playMovingSound(player, this, SoundEvents.ENTITY_PIG_SADDLE, SoundCategory.AMBIENT, 0.5F, 1.0F);
 			return ActionResultType.CONSUME;
 
-		//============================================//
-		//                Horn Armor                  //
-		//	There has to be a better way to do this...//
-		//============================================//
 
-		} else if ((!this.hasHornArmor() || this.getItemStackFromSlot(EquipmentSlotType.HEAD).getItem() == Items.AIR) && this.isTamed() && !this.isChild() && item == RCItems.LEATHER_HORN_ARMOR.get()) {
-			if (!player.abilities.isCreativeMode) {
-				itemstack.shrink(1);
-			}
-			setItemStackToSlot(EquipmentSlotType.HEAD, new ItemStack(RCItems.LEATHER_HORN_ARMOR.get()));
-			world.playMovingSound(player, this, SoundEvents.ITEM_ARMOR_EQUIP_LEATHER, SoundCategory.AMBIENT, 0.5F, 1.0F);
-			this.setHasHornArmor(true);
-			return ActionResultType.CONSUME;
-		} else if ((!this.hasHornArmor() || this.getItemStackFromSlot(EquipmentSlotType.HEAD).getItem() == Items.AIR) && this.isTamed() && !this.isChild() && item == RCItems.GOLDEN_HORN_ARMOR.get()) {
-			if (!player.abilities.isCreativeMode) {
-				itemstack.shrink(1);
-			}
-			setItemStackToSlot(EquipmentSlotType.HEAD, new ItemStack(RCItems.GOLDEN_HORN_ARMOR.get()));
-			world.playMovingSound(player, this, SoundEvents.ITEM_ARMOR_EQUIP_GOLD, SoundCategory.AMBIENT, 0.5F, 1.0F);
-			this.setHasHornArmor(true);
-			return ActionResultType.CONSUME;
-		} else if ((!this.hasHornArmor() || this.getItemStackFromSlot(EquipmentSlotType.HEAD).getItem() == Items.AIR) && this.isTamed() && !this.isChild() && item == RCItems.IRON_HORN_ARMOR.get()) {
-			if (!player.abilities.isCreativeMode) {
-				itemstack.shrink(1);
-			}
-			setItemStackToSlot(EquipmentSlotType.HEAD, new ItemStack(RCItems.IRON_HORN_ARMOR.get()));
-			world.playMovingSound(player, this, SoundEvents.ITEM_ARMOR_EQUIP_IRON, SoundCategory.AMBIENT, 0.5F, 1.0F);
-			this.setHasHornArmor(true);
-			return ActionResultType.CONSUME;
-		} else if ((!this.hasHornArmor() || this.getItemStackFromSlot(EquipmentSlotType.HEAD).getItem() == Items.AIR) && this.isTamed() && !this.isChild() && item == RCItems.DIAMOND_HORN_ARMOR.get()) {
-			if (!player.abilities.isCreativeMode) {
-				itemstack.shrink(1);
-			}
-			setItemStackToSlot(EquipmentSlotType.HEAD, new ItemStack(RCItems.DIAMOND_HORN_ARMOR.get()));
-			world.playMovingSound(player, this, SoundEvents.ITEM_ARMOR_EQUIP_DIAMOND, SoundCategory.AMBIENT, 0.5F, 1.0F);
-			this.setHasHornArmor(true);
-			return ActionResultType.CONSUME;
-		} else if ((!this.hasHornArmor() || this.getItemStackFromSlot(EquipmentSlotType.HEAD).getItem() == Items.AIR) && this.isTamed() && !this.isChild() && item == RCItems.NETHERITE_HORN_ARMOR.get()) {
-			if (!player.abilities.isCreativeMode) {
-				itemstack.shrink(1);
-			}
-			setItemStackToSlot(EquipmentSlotType.HEAD, new ItemStack(RCItems.NETHERITE_HORN_ARMOR.get()));
-			world.playMovingSound(player, this, SoundEvents.ITEM_ARMOR_EQUIP_NETHERITE, SoundCategory.AMBIENT, 0.5F, 1.0F);
-			this.setHasHornArmor(true);
-			return ActionResultType.CONSUME;
+		} else if ((!this.hasHornArmor() || this.getItemStackFromSlot(EquipmentSlotType.HEAD).isEmpty()) && this.isTamed() && !this.isChild() && item instanceof IRavagerHornArmorItem) {
 
-		// End of horn armor
+			this.setItemStackToSlot(EquipmentSlotType.HEAD, itemstack.copy());
+			if (!player.abilities.isCreativeMode) {
+				itemstack.shrink(1);
+			}
 
+			IRavagerHornArmorItem hornArmorItem = (IRavagerHornArmorItem)item;
+			world.playMovingSound(player, this, hornArmorItem.getArmorMaterial().getSoundEvent(), SoundCategory.AMBIENT, 0.5F, 1.0F);
+
+			return ActionResultType.CONSUME;
 		} else if (this.isSaddled() && item == Items.AIR) {
 			player.startRiding(this);
 			return ActionResultType.SUCCESS;

--- a/src/main/java/superlord/ravagecabbage/init/RCItems.java
+++ b/src/main/java/superlord/ravagecabbage/init/RCItems.java
@@ -18,11 +18,11 @@ public class RCItems {
     public static final RegistryObject<Item> CABBAGE_SEEDS = REGISTER.register("cabbage_seeds", () -> new BlockNamedItem(RCBlocks.CABBAGE_CROP.get(), new Item.Properties().group(RavageAndCabbage.GROUP)));
     public static final RegistryObject<Item> RAVAGER_MILK = REGISTER.register("ravager_milk", () -> new RavagerMilkItem(new Item.Properties().group(RavageAndCabbage.GROUP).maxStackSize(1)));
     public static final RegistryObject<Item> CABBAGE_THROWABLE = REGISTER.register("throwable_cabbage", () -> new ThrowableCabbageItem(new Item.Properties().maxStackSize(1)));
-    public static final RegistryObject<Item> LEATHER_HORN_ARMOR = REGISTER.register("leather_horn_armor", () -> new DyeableRavagerHornArmorItem(1, "leather", new Item.Properties().group(RavageAndCabbage.GROUP).maxDamage(45).maxStackSize(1)));
-    public static final RegistryObject<Item> GOLDEN_HORN_ARMOR = REGISTER.register("golden_horn_armor", () -> new RavagerHornArmorItem(3, "golden", new Item.Properties().group(RavageAndCabbage.GROUP).maxDamage(50).maxStackSize(1), ArmorMaterial.GOLD));
-    public static final RegistryObject<Item> IRON_HORN_ARMOR = REGISTER.register("iron_horn_armor", () -> new RavagerHornArmorItem(2, "iron", new Item.Properties().group(RavageAndCabbage.GROUP).maxDamage(75).maxStackSize(1), ArmorMaterial.IRON));
-    public static final RegistryObject<Item> DIAMOND_HORN_ARMOR = REGISTER.register("diamond_horn_armor", () -> new RavagerHornArmorItem(5, "diamond", new Item.Properties().group(RavageAndCabbage.GROUP).maxDamage(100).maxStackSize(1), ArmorMaterial.DIAMOND));
-    public static final RegistryObject<Item> NETHERITE_HORN_ARMOR = REGISTER.register("netherite_horn_armor", () -> new RavagerHornArmorItem(8, "netherite", new Item.Properties().group(RavageAndCabbage.GROUP).maxDamage(150).isImmuneToFire().maxStackSize(1), ArmorMaterial.NETHERITE));
+    public static final RegistryObject<Item> LEATHER_HORN_ARMOR = REGISTER.register("leather_horn_armor", () -> new DyeableRavagerHornArmorItem(1, "leather", new Item.Properties().group(RavageAndCabbage.GROUP).maxDamage(45)));
+    public static final RegistryObject<Item> GOLDEN_HORN_ARMOR = REGISTER.register("golden_horn_armor", () -> new RavagerHornArmorItem(3, "golden", new Item.Properties().group(RavageAndCabbage.GROUP).maxDamage(50), ArmorMaterial.GOLD));
+    public static final RegistryObject<Item> IRON_HORN_ARMOR = REGISTER.register("iron_horn_armor", () -> new RavagerHornArmorItem(2, "iron", new Item.Properties().group(RavageAndCabbage.GROUP).maxDamage(75), ArmorMaterial.IRON));
+    public static final RegistryObject<Item> DIAMOND_HORN_ARMOR = REGISTER.register("diamond_horn_armor", () -> new RavagerHornArmorItem(5, "diamond", new Item.Properties().group(RavageAndCabbage.GROUP).maxDamage(100), ArmorMaterial.DIAMOND));
+    public static final RegistryObject<Item> NETHERITE_HORN_ARMOR = REGISTER.register("netherite_horn_armor", () -> new RavagerHornArmorItem(8, "netherite", new Item.Properties().group(RavageAndCabbage.GROUP).maxDamage(150).isImmuneToFire(), ArmorMaterial.NETHERITE));
 
     // Spawn Eggs
     public static final RegistryObject<Item> CABBAGER_SPAWN_EGG = REGISTER.register("cabbager_spawn_egg", () -> new RavageAndCabbageSpawnEggItem(RCEntities.CABBAGER, 0x959B9B, 0x708438, new Item.Properties().group(RavageAndCabbage.GROUP)));

--- a/src/main/java/superlord/ravagecabbage/init/RCItems.java
+++ b/src/main/java/superlord/ravagecabbage/init/RCItems.java
@@ -1,5 +1,6 @@
 package superlord.ravagecabbage.init;
 
+import net.minecraft.item.ArmorMaterial;
 import net.minecraft.item.BlockNamedItem;
 import net.minecraft.item.Food;
 import net.minecraft.item.Item;
@@ -17,11 +18,11 @@ public class RCItems {
     public static final RegistryObject<Item> CABBAGE_SEEDS = REGISTER.register("cabbage_seeds", () -> new BlockNamedItem(RCBlocks.CABBAGE_CROP.get(), new Item.Properties().group(RavageAndCabbage.GROUP)));
     public static final RegistryObject<Item> RAVAGER_MILK = REGISTER.register("ravager_milk", () -> new RavagerMilkItem(new Item.Properties().group(RavageAndCabbage.GROUP).maxStackSize(1)));
     public static final RegistryObject<Item> CABBAGE_THROWABLE = REGISTER.register("throwable_cabbage", () -> new ThrowableCabbageItem(new Item.Properties().maxStackSize(1)));
-    public static final RegistryObject<Item> LEATHER_HORN_ARMOR = REGISTER.register("leather_horn_armor", () -> new DyeableRavagerHornArmorItem(1, "leather", new Item.Properties().group(RavageAndCabbage.GROUP).maxDamage(45)));
-    public static final RegistryObject<Item> GOLDEN_HORN_ARMOR = REGISTER.register("golden_horn_armor", () -> new RavagerHornArmorItem(3, "golden", new Item.Properties().group(RavageAndCabbage.GROUP).maxDamage(50)));
-    public static final RegistryObject<Item> IRON_HORN_ARMOR = REGISTER.register("iron_horn_armor", () -> new RavagerHornArmorItem(2, "iron", new Item.Properties().group(RavageAndCabbage.GROUP).maxDamage(75)));
-    public static final RegistryObject<Item> DIAMOND_HORN_ARMOR = REGISTER.register("diamond_horn_armor", () -> new RavagerHornArmorItem(5, "diamond", new Item.Properties().group(RavageAndCabbage.GROUP).maxDamage(100)));
-    public static final RegistryObject<Item> NETHERITE_HORN_ARMOR = REGISTER.register("netherite_horn_armor", () -> new RavagerHornArmorItem(8, "netherite", new Item.Properties().group(RavageAndCabbage.GROUP).maxDamage(150)));
+    public static final RegistryObject<Item> LEATHER_HORN_ARMOR = REGISTER.register("leather_horn_armor", () -> new DyeableRavagerHornArmorItem(1, "leather", new Item.Properties().group(RavageAndCabbage.GROUP).maxDamage(45).maxStackSize(1)));
+    public static final RegistryObject<Item> GOLDEN_HORN_ARMOR = REGISTER.register("golden_horn_armor", () -> new RavagerHornArmorItem(3, "golden", new Item.Properties().group(RavageAndCabbage.GROUP).maxDamage(50).maxStackSize(1), ArmorMaterial.GOLD));
+    public static final RegistryObject<Item> IRON_HORN_ARMOR = REGISTER.register("iron_horn_armor", () -> new RavagerHornArmorItem(2, "iron", new Item.Properties().group(RavageAndCabbage.GROUP).maxDamage(75).maxStackSize(1), ArmorMaterial.IRON));
+    public static final RegistryObject<Item> DIAMOND_HORN_ARMOR = REGISTER.register("diamond_horn_armor", () -> new RavagerHornArmorItem(5, "diamond", new Item.Properties().group(RavageAndCabbage.GROUP).maxDamage(100).maxStackSize(1), ArmorMaterial.DIAMOND));
+    public static final RegistryObject<Item> NETHERITE_HORN_ARMOR = REGISTER.register("netherite_horn_armor", () -> new RavagerHornArmorItem(8, "netherite", new Item.Properties().group(RavageAndCabbage.GROUP).maxDamage(150).isImmuneToFire().maxStackSize(1), ArmorMaterial.NETHERITE));
 
     // Spawn Eggs
     public static final RegistryObject<Item> CABBAGER_SPAWN_EGG = REGISTER.register("cabbager_spawn_egg", () -> new RavageAndCabbageSpawnEggItem(RCEntities.CABBAGER, 0x959B9B, 0x708438, new Item.Properties().group(RavageAndCabbage.GROUP)));

--- a/src/main/java/superlord/ravagecabbage/items/DyeableRavagerHornArmorItem.java
+++ b/src/main/java/superlord/ravagecabbage/items/DyeableRavagerHornArmorItem.java
@@ -1,13 +1,18 @@
 package superlord.ravagecabbage.items;
 
+import net.minecraft.item.ArmorMaterial;
 import net.minecraft.item.IDyeableArmorItem;
 import net.minecraft.item.Item;
+import net.minecraft.util.SoundEvent;
+import net.minecraft.util.SoundEvents;
 
 public class DyeableRavagerHornArmorItem extends RavagerHornArmorItem implements IDyeableArmorItem {
+
     public DyeableRavagerHornArmorItem(int armorValue, String p_i50047_2_, Item.Properties builder) {
-        super(armorValue, p_i50047_2_, builder);
+        super(armorValue, p_i50047_2_, builder, ArmorMaterial.LEATHER);
     }
     public DyeableRavagerHornArmorItem(int armorValue, net.minecraft.util.ResourceLocation texture, Item.Properties builder) {
-        super(armorValue, texture, builder);
+        super(armorValue, texture, builder, ArmorMaterial.LEATHER);
     }
+
 }

--- a/src/main/java/superlord/ravagecabbage/items/IRavagerHornArmorItem.java
+++ b/src/main/java/superlord/ravagecabbage/items/IRavagerHornArmorItem.java
@@ -1,7 +1,6 @@
 package superlord.ravagecabbage.items;
 
 import net.minecraft.item.ArmorMaterial;
-import net.minecraft.util.SoundEvent;
 
 public interface IRavagerHornArmorItem {
 

--- a/src/main/java/superlord/ravagecabbage/items/IRavagerHornArmorItem.java
+++ b/src/main/java/superlord/ravagecabbage/items/IRavagerHornArmorItem.java
@@ -1,0 +1,10 @@
+package superlord.ravagecabbage.items;
+
+import net.minecraft.item.ArmorMaterial;
+import net.minecraft.util.SoundEvent;
+
+public interface IRavagerHornArmorItem {
+
+    ArmorMaterial getArmorMaterial();
+    int getArmorValue();
+}

--- a/src/main/java/superlord/ravagecabbage/items/RavagerHornArmorItem.java
+++ b/src/main/java/superlord/ravagecabbage/items/RavagerHornArmorItem.java
@@ -2,20 +2,23 @@ package superlord.ravagecabbage.items;
 
 import net.minecraft.item.Item;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.item.ArmorMaterial;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import superlord.ravagecabbage.RavageAndCabbage;
 
-public class RavagerHornArmorItem extends Item {
+public class RavagerHornArmorItem extends Item implements IRavagerHornArmorItem {
     private final int armorValue;
     private final ResourceLocation tex;
+    private final ArmorMaterial armorMaterial;
 
-    public RavagerHornArmorItem(int armorValue, String tierArmor, Item.Properties builder) {
-        this(armorValue, new ResourceLocation(RavageAndCabbage.MOD_ID, "textures/entity/ravager_equipment/" + tierArmor + "_horns.png"), builder);
+    public RavagerHornArmorItem(int armorValue, String tierArmor, Item.Properties builder, ArmorMaterial armorMaterial) {
+        this(armorValue, new ResourceLocation(RavageAndCabbage.MOD_ID, "textures/entity/ravager_equipment/" + tierArmor + "_horns.png"), builder, armorMaterial);
     }
 
-    public RavagerHornArmorItem(int armorValue, ResourceLocation texture, Item.Properties builder) {
+    public RavagerHornArmorItem(int armorValue, ResourceLocation texture, Item.Properties builder, ArmorMaterial armorMaterial) {
         super(builder);
+        this.armorMaterial = armorMaterial;
         this.armorValue = armorValue;
         this.tex = texture;
     }
@@ -23,6 +26,10 @@ public class RavagerHornArmorItem extends Item {
     @OnlyIn(Dist.CLIENT)
     public ResourceLocation getArmorTexture() {
         return tex;
+    }
+
+    public ArmorMaterial getArmorMaterial() {
+        return this.armorMaterial;
     }
 
     public int getArmorValue() {


### PR DESCRIPTION
Added IRavagerHornArmorItem interface. It uses Minecraft's default ArmorMaterial class so equipping  any kind of RavagerHornArmorItem subclass can use same code path in  RCRavagerEntity.java. ArmorMaterial also abstracts the correct SoundEvent for equipping. RCRavagerEntity.setItemStackToSlot() was overridden so when a RavagerHornArmorItem is set for EquipmentSlot.HEAD the Entity's Attributes.ARMOR value is updated accordingly. Attributes.ARMOR base value is initialized to 0 so the attribute is available for modifications. Unequipping of HornArmorItem can be done with empty hand while sneaking. The Item is dropped on the ground for now due to the lack of an INamedContainerProvider. But I will happily implement that next time, so armor can be equipped like we do with a horse while looking at the Entity's inventory. Btw, build.gradle needs to be updated to forge 1.16.5-36.1.0 for this to be build. 